### PR TITLE
Add version cli argument

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,11 @@ fn main() -> Result<()> {
     let interval = args.interval;
     let json_mode = args.json;
 
+    if args.version {
+        println!("{} {}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
+        return Ok(());
+    }
+
     if args.dump {
         match macpow::ioreport::IOReportSampler::new() {
             Ok(ior) => ior.dump_channels(),

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,7 +2,7 @@ use clap::Parser;
 use serde::Serialize;
 
 #[derive(Parser, Debug)]
-#[command(name = "macpow", about = "Apple Silicon Power Monitor TUI")]
+#[command(name = env!("CARGO_PKG_NAME"), about = concat!("Apple Silicon Power Monitor TUI ", env!("CARGO_PKG_VERSION")))]
 pub struct CliArgs {
     /// Sampling interval in milliseconds
     #[arg(long, default_value_t = 500)]
@@ -15,6 +15,10 @@ pub struct CliArgs {
     /// Dump all IOReport channel names and exit (for diagnostics)
     #[arg(long)]
     pub dump: bool,
+
+    /// Show the version
+    #[arg(long)]
+    pub version: bool,
 }
 
 #[derive(Debug, Clone, Default, Serialize)]


### PR DESCRIPTION
This adds a `--version` flag to the CLI. When used, the program prints the project name and version (from `Cargo.toml`) and exits immediately.

I thought this would be a nice small change/improvement.