### PR TITLE
Add flake.nix for Nix build support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1776225522,
+        "narHash": "sha256-W2npO5nesUm68vECpC3Dl/IOzamvcGAu9uV38hou2yg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "975dad1a84d727dce241bb41b27191948fa5a956",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,62 @@
+{
+  description = "Real-time power consumption monitor for Apple Silicon Macs";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  };
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      supportedSystems = [
+        "aarch64-darwin"
+        "x86_64-darwin"
+      ];
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+    in
+    {
+      packages = forAllSystems (
+        system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          default = pkgs.rustPlatform.buildRustPackage {
+            pname = "macpow";
+            version = "0.1.17";
+
+            src = ./.;
+            cargoLock.lockFile = ./Cargo.lock;
+
+            buildInputs = [
+              pkgs.apple-sdk_15
+            ];
+
+            meta = {
+              description = "Real-time power consumption monitor for Apple Silicon Macs";
+              homepage = "https://github.com/k06a/macpow";
+              license = pkgs.lib.licenses.mit;
+              platforms = pkgs.lib.platforms.darwin;
+              mainProgram = "macpow";
+            };
+          };
+        }
+      );
+
+      devShells = forAllSystems (
+        system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          default = pkgs.mkShell {
+            inputsFrom = [ self.packages.${system}.default ];
+            packages = with pkgs; [
+              rust-analyzer
+              clippy
+            ];
+          };
+        }
+      );
+    };
+}


### PR DESCRIPTION
## Summary

Adds a Nix flake that builds macpow using `rustPlatform.buildRustPackage`.

## What's included

- **`flake.nix`** — Nix build expression targeting `aarch64-darwin` and `x86_64-darwin`
  - Uses `apple-sdk_15` for the required macOS frameworks (IOKit, CoreFoundation, CoreWLAN, CoreGraphics, CoreAudio)
  - Uses `cargoLock.lockFile` to vendor dependencies from the existing `Cargo.lock`
  - Includes a `devShell` with `rust-analyzer` and `clippy`
- **`flake.lock`** — pinned nixpkgs input

## Usage

```bash
# Build
nix build

# Run directly
nix run

# Enter dev shell
nix develop
```

## Tested

- ✅ `nix build` produces `result/bin/macpow` — verified `macpow 0.1.17`