### PR TITLE
fix: decode pmset accessory names as MacRoman

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,6 +418,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -610,6 +619,7 @@ dependencies = [
  "core-foundation-sys",
  "criterion",
  "crossterm 0.29.0",
+ "encoding_rs",
  "libc",
  "ratatui",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ serde_json = "1"
 core-foundation = "0.10"
 core-foundation-sys = "0.8"
 libc = "0.2"
+encoding_rs = "0.8"
 unicode-width = { version = "0.2.0", optional = true }
 
 [package.metadata.binstall]

--- a/src/ioreport.rs
+++ b/src/ioreport.rs
@@ -131,10 +131,8 @@ fn parse_cpu_stats_core_key(name: &str) -> Option<CpuCoreKey> {
         (CpuKind::Efficiency, rest)
     } else if let Some(rest) = name.strip_prefix("MCPU") {
         (CpuKind::Efficiency, rest)
-    } else if let Some(rest) = name.strip_prefix("PCPU") {
-        (CpuKind::Performance, rest)
     } else {
-        return None;
+        (CpuKind::Performance, name.strip_prefix("PCPU")?)
     };
 
     // Digit-suffix format: ECPU0, PCPU10 (single-die M1/M2/M3/M4)

--- a/src/peripherals.rs
+++ b/src/peripherals.rs
@@ -450,8 +450,20 @@ pub fn read_bluetooth_devices() -> Vec<BluetoothDevice> {
         &["-g", "accps"],
         std::time::Duration::from_millis(1000),
     ) {
-        Some(o) if o.status.success() => String::from_utf8_lossy(&o.stdout).to_string(),
+        Some(o) if o.status.success() => o.stdout,
         _ => return Vec::new(),
+    };
+
+    parse_bluetooth_devices(&output)
+}
+
+fn parse_bluetooth_devices(output: &[u8]) -> Vec<BluetoothDevice> {
+    let output = match std::str::from_utf8(output) {
+        Ok(text) => std::borrow::Cow::Borrowed(text),
+        Err(_) => {
+            let (text, _, _) = encoding_rs::MACINTOSH.decode(output);
+            text
+        }
     };
 
     struct Entry {
@@ -556,4 +568,32 @@ pub fn read_bluetooth_devices() -> Vec<BluetoothDevice> {
     }
 
     devices
+}
+
+#[cfg(test)]
+mod bluetooth_tests {
+    use super::parse_bluetooth_devices;
+
+    #[test]
+    fn parses_mac_roman_bluetooth_device_names_without_replacement_chars() {
+        let output = b"Now drawing from 'AC Power'\n\
+ -Sample\xD5s Magic Keyboard (id=58458112)\t97%; discharging present: true\n";
+
+        let devices = parse_bluetooth_devices(output);
+
+        assert_eq!(devices.len(), 1);
+        assert_eq!(devices[0].name, "Sample\u{2019}s Magic Keyboard");
+        assert!(!devices[0].name.contains('\u{FFFD}'));
+    }
+
+    #[test]
+    fn preserves_utf8_bluetooth_device_names() {
+        let output = "Now drawing from 'AC Power'\n\
+ -Sample’s Keyboard (id=58458112)\t97%; discharging present: true\n";
+
+        let devices = parse_bluetooth_devices(output.as_bytes());
+
+        assert_eq!(devices.len(), 1);
+        assert_eq!(devices[0].name, "Sample’s Keyboard");
+    }
 }


### PR DESCRIPTION
## Summary

Fix Bluetooth accessory names containing MacRoman characters being rendered as the Unicode replacement character (`�`).

For example:

- Expected: `yuchen’s Magic Keyboard`
- Actual: `yuchen�s Magic Keyboard`

## Root cause

On macOS, `pmset -g accps` can emit accessory names using MacRoman. Byte `0xD5` represents `U+2019 RIGHT SINGLE QUOTATION MARK` in MacRoman. macpow decoded the complete stdout buffer with `String::from_utf8_lossy`, which replaced that byte with `U+FFFD`.

## Changes

- Preserve valid UTF-8 output unchanged.
- Fall back to MacRoman decoding when `pmset` output is not valid UTF-8.
- Extract Bluetooth output parsing into a testable function.
- Add regression tests for MacRoman and UTF-8 device names.
- Apply a behavior-preserving Rust 1.97 Clippy compatibility refactor.

## Verification

- `cargo check --release`
- `cargo fmt --check`
- `cargo test --lib`
- Repository CI Clippy command
- Regression tests for both MacRoman and UTF-8 names
- Manual TUI verification: device names render without replacement characters

Closes #19